### PR TITLE
Fix Typo in Overview

### DIFF
--- a/fsh/ig-data/input/SANER-overview.md
+++ b/fsh/ig-data/input/SANER-overview.md
@@ -108,7 +108,7 @@ set of characteristics.  The [MeasureReport](https://hl7.org/fhir/R4/measurerepo
 resource can report on measures using counts and other metrics over a variety of resources.
 
 ###### Device Resource
-The Device Resource can report on medical devices, including ventilators, repirators,
+The Device Resource can report on medical devices, including ventilators, respirators,
 personal protective equipment such as masks, and viral test kits.  Device is not widely
 used by systems reporting on device quantities or status.
 

--- a/fsh/ig-data/input/pagecontent/1_overview.md
+++ b/fsh/ig-data/input/pagecontent/1_overview.md
@@ -115,7 +115,7 @@ set of characteristics.  The [MeasureReport](https://hl7.org/fhir/R4/measurerepo
 resource can report on measures using counts and other metrics over a variety of resources.
 
 ###### Device Resource
-The Device Resource can report on medical devices, including ventilators, repirators,
+The Device Resource can report on medical devices, including ventilators, respirators,
 personal protective equipment such as masks, and viral test kits.  Device is not widely
 used by systems reporting on device quantities or status.
 


### PR DESCRIPTION
Tiny fix for a suspected typo (`repirator` -> `respirators`) in the IG.

Relevant part of the IG: http://build.fhir.org/ig/HL7/fhir-saner/overview.html#device-resource